### PR TITLE
Add header property

### DIFF
--- a/outlook_msg/constants.py
+++ b/outlook_msg/constants.py
@@ -8,6 +8,7 @@ SUBSTG_PREFIX = '__substg1.0_'
 PROPERTY_IDS = {
     '0x0C1F': 'PidTagSenderEmailAddress',
     '0x0037': 'PidTagSubject',
+    '0x007D': 'PidTagHeader',
     '0x1000': 'PidTagBody',
     '0x1013': 'PidTagBodyHtml',
     '0x1009': 'PidTagRtfCompressed',

--- a/outlook_msg/message.py
+++ b/outlook_msg/message.py
@@ -20,6 +20,10 @@ class Message:
         return self.mfs['PidTagBody']
 
     @property
+    def header(self):
+        return self.mfs['PidTagHeader']
+
+    @property
     def has_attachments(self):
         try:
             return self.mfs['PidTagHasAttachments']

--- a/tests/test_outlook_msg.py
+++ b/tests/test_outlook_msg.py
@@ -25,6 +25,10 @@ def test_message_body(message):
     assert message.body.strip() == 'This is a test body with a single line.'
 
 
+def test_message_header(message):
+    assert 'Thread-Index: AdRfI65MmNrKSpldS8Sse7WZgcpbkg==' in message.header
+
+
 def test_message_sender(message):
     assert message.sender_email == "/O=EXCHANGELABS/OU=EXCHANGE ADMINISTRATIVE GROUP (FYDIBOHF23SPDLT)/CN=RECIPIENTS/CN=17A93D132C634197AFD774F396AFFB26-ELLIOT HUGH"
 


### PR DESCRIPTION
Having a body and a header property will allow further processing via `email.parser`.